### PR TITLE
Bump version of haystack-logback-metrics-appender to 0.1.3, which

### DIFF
--- a/indexer/pom.xml
+++ b/indexer/pom.xml
@@ -86,7 +86,6 @@
         <dependency>
             <groupId>com.expedia.www</groupId>
             <artifactId>haystack-logback-metrics-appender</artifactId>
-            <version>0.1.1</version>
         </dependency>
 
         <!-- Test Dependencies  -->

--- a/indexer/src/main/resources/config/base.conf
+++ b/indexer/src/main/resources/config/base.conf
@@ -1,6 +1,6 @@
 health.status.path = "/app/isHealthy"
 
-haystack.graphite.address = "monitoring-influxdb-graphite.kube-system.svc"
+haystack.graphite.host = "monitoring-influxdb-graphite.kube-system.svc"
 
 span.accumulate {
   store {

--- a/indexer/src/main/resources/logback.xml
+++ b/indexer/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
 
     <appender name="EmitToGraphiteLogbackAppender"
               class="com.expedia.www.haystack.metrics.appenders.logback.EmitToGraphiteLogbackAppender">
-        <address>${HAYSTACK_GRAPHITE_ADDRESS}</address>
+        <host>${HAYSTACK_GRAPHITE_HOST}</host>
     </appender>
 
     <root level="${HAYSTACK_LOG_LEVEL:-INFO}">

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <scala.major.version>2</scala.major.version>
         <scala.minor.version>11</scala.minor.version>
         <scala.tiny.version>8</scala.tiny.version>
+        <haystack.logback.metrics.appender.version>0.1.3</haystack.logback.metrics.appender.version>
         <scala.major.minor.version>${scala.major.version}.${scala.minor.version}</scala.major.minor.version>
         <scala-library.version>${scala.major.version}.${scala.minor.version}.${scala.tiny.version}</scala-library.version>
 
@@ -105,6 +106,11 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.expedia.www</groupId>
+                <artifactId>haystack-logback-metrics-appender</artifactId>
+                <version>${haystack.logback.metrics.appender.version}</version>
             </dependency>
 
             <!-- elastic search -->

--- a/reader/pom.xml
+++ b/reader/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>com.expedia.www</groupId>
             <artifactId>haystack-logback-metrics-appender</artifactId>
-            <version>0.1.1</version>
         </dependency>
 
     </dependencies>

--- a/reader/src/main/resources/config/base.conf
+++ b/reader/src/main/resources/config/base.conf
@@ -1,4 +1,4 @@
-haystack.graphite.address = "monitoring-influxdb-graphite.kube-system.svc"
+haystack.graphite.host = "monitoring-influxdb-graphite.kube-system.svc"
 
 service {
     port = 8088

--- a/reader/src/main/resources/logback.xml
+++ b/reader/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
 
     <appender name="EmitToGraphiteLogbackAppender"
               class="com.expedia.www.haystack.metrics.appenders.logback.EmitToGraphiteLogbackAppender">
-        <address>${HAYSTACK_GRAPHITE_ADDRESS}</address>
+        <host>${HAYSTACK_GRAPHITE_HOST}</host>
     </appender>
 
     <root level="${HAYSTACK_LOG_LEVEL:-INFO}">


### PR DESCRIPTION
requires changing the haystack.graphite.address configuration name to
haystack.graphite.host.