### PR TITLE
Add HOCON config functionality with config.resolve()

### DIFF
--- a/commons/src/main/scala/com/expedia/www/haystack/trace/commons/config/ConfigurationLoader.scala
+++ b/commons/src/main/scala/com/expedia/www/haystack/trace/commons/config/ConfigurationLoader.scala
@@ -36,8 +36,8 @@ object ConfigurationLoader {
     val baseConfig = ConfigFactory.load("config/base.conf")
 
     sys.env.get("HAYSTACK_OVERRIDES_CONFIG_PATH") match {
-      case Some(path) => ConfigFactory.parseFile(new File(path)).withFallback(baseConfig)
-      case _ => loadFromEnvVars().withFallback(baseConfig)
+      case Some(path) => ConfigFactory.parseFile(new File(path)).withFallback(baseConfig).resolve()
+      case _ => loadFromEnvVars().withFallback(baseConfig).resolve()
     }
   }
 


### PR DESCRIPTION
In order to add the HOCON "Optional system or env variable overrides" ([https://github.com/lightbend/config#optional-system-or-env-variable-overrides](https://github.com/lightbend/config#optional-system-or-env-variable-overrides)) functionality with the lightbend config objects, I added the .resolve() method ([https://lightbend.github.io/config/latest/api/com/typesafe/config/Config.html#resolve--](https://lightbend.github.io/config/latest/api/com/typesafe/config/Config.html#resolve--)) to the loadAppConfig method in the Configuration Loader.

In this way, user config files can easily define a value using either a default or, if set, an environment variable.