### PR TITLE
Obfuscate passwords in config logging

### DIFF
--- a/commons/src/main/scala/com/expedia/www/haystack/trace/commons/config/ConfigurationLoader.scala
+++ b/commons/src/main/scala/com/expedia/www/haystack/trace/commons/config/ConfigurationLoader.scala
@@ -50,7 +50,8 @@ object ConfigurationLoader {
       case _ => loadFromEnv(sys.env, keysWithArrayValues).withFallback(baseConfig).resolve()
     }
 
-    LOGGER.info(config.root().render())
+    // In key-value pairs that contain 'password' in the key, replace the value with asterisks
+    LOGGER.info(config.root().render().replaceAll("(?i)(\\\".*password\\\"\\s*:\\s*)\\\".+\\\"", "$1********"))
 
     config
   }


### PR DESCRIPTION
We've noticed that, when starting up, the Indexer prints out the entire configuration file that it's using. While useful for debugging, it does print out plaintext passwords.

This change using a regex finds all key value pairs in the string that's about to be logged that contain "password" somewhere in the key, and replaces the value with ********