### PR TITLE
fixed code and integration test to create the haystack cassandra keyspace

### DIFF
--- a/indexer/src/main/scala/com/expedia/www/haystack/trace/indexer/writers/cassandra/CassandraTraceWriter.scala
+++ b/indexer/src/main/scala/com/expedia/www/haystack/trace/indexer/writers/cassandra/CassandraTraceWriter.scala
@@ -38,6 +38,8 @@ class CassandraTraceWriter(cassandra: CassandraSession,
 
   private val LOGGER = LoggerFactory.getLogger(classOf[CassandraTraceWriter])
 
+  cassandra.ensureKeyspace(config.clientConfig.tracesKeyspace)
+
   private val writeTimer = metricRegistry.timer(AppMetricNames.CASSANDRA_WRITE_TIME)
   private val writeFailures = metricRegistry.meter(AppMetricNames.CASSANDRA_WRITE_FAILURE)
 
@@ -46,7 +48,6 @@ class CassandraTraceWriter(cassandra: CassandraSession,
   // this semaphore controls the parallel writes to cassandra
   private val inflightRequestsSemaphore = new Semaphore(config.maxInFlightRequests, true)
 
-  cassandra.ensureKeyspace(config.clientConfig.tracesKeyspace)
 
   private def execute(traceId: String, packedSpanBuffer: PackedMessage[SpanBuffer]): Unit = {
     // execute the request async with retry

--- a/indexer/src/test/scala/com/expedia/www/haystack/trace/indexer/integration/clients/CassandraTestClient.scala
+++ b/indexer/src/test/scala/com/expedia/www/haystack/trace/indexer/integration/clients/CassandraTestClient.scala
@@ -40,8 +40,8 @@ class CassandraTestClient {
   private val metadataSchema = Some("CREATE KEYSPACE IF NOT EXISTS haystack_metadata WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor' : 1} AND durable_writes = false;\n\nCREATE TABLE haystack_metadata.services (\nservice_name varchar,\noperation_name varchar,\nts timestamp,\nPRIMARY KEY ((service_name), operation_name)\n) WITH CLUSTERING ORDER BY (operation_name ASC);\n\nALTER TABLE haystack_metadata.services WITH compaction = { 'class' :  'DateTieredCompactionStrategy'  };")
 
   def prepare(): Unit = {
-    cassandraSession.execute(new SimpleStatement(s"DROP KEYSPACE  $KEYSPACE IF EXISTS"))
-    cassandraSession.execute(new SimpleStatement(s"DROP KEYSPACE $SERVICES_METADATA_KEYSPACE IF EXISTS"))
+    cassandraSession.execute(new SimpleStatement(s"DROP KEYSPACE IF EXISTS $KEYSPACE"))
+    cassandraSession.execute(new SimpleStatement(s"DROP KEYSPACE IF EXISTS $SERVICES_METADATA_KEYSPACE"))
   }
 
   def buildServiceMetadataConfig: ServiceMetadataWriteConfiguration = {

--- a/indexer/src/test/scala/com/expedia/www/haystack/trace/indexer/integration/clients/CassandraTestClient.scala
+++ b/indexer/src/test/scala/com/expedia/www/haystack/trace/indexer/integration/clients/CassandraTestClient.scala
@@ -40,8 +40,8 @@ class CassandraTestClient {
   private val metadataSchema = Some("CREATE KEYSPACE IF NOT EXISTS haystack_metadata WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor' : 1} AND durable_writes = false;\n\nCREATE TABLE haystack_metadata.services (\nservice_name varchar,\noperation_name varchar,\nts timestamp,\nPRIMARY KEY ((service_name), operation_name)\n) WITH CLUSTERING ORDER BY (operation_name ASC);\n\nALTER TABLE haystack_metadata.services WITH compaction = { 'class' :  'DateTieredCompactionStrategy'  };")
 
   def prepare(): Unit = {
-    cassandraSession.execute(new SimpleStatement(s"DROP KEYSPACE  $KEYSPACE"))
-    cassandraSession.execute(new SimpleStatement(s"DROP KEYSPACE $SERVICES_METADATA_KEYSPACE"))
+    cassandraSession.execute(new SimpleStatement(s"DROP KEYSPACE  $KEYSPACE IF EXISTS"))
+    cassandraSession.execute(new SimpleStatement(s"DROP KEYSPACE $SERVICES_METADATA_KEYSPACE IF EXISTS"))
   }
 
   def buildServiceMetadataConfig: ServiceMetadataWriteConfiguration = {

--- a/indexer/src/test/scala/com/expedia/www/haystack/trace/indexer/integration/clients/CassandraTestClient.scala
+++ b/indexer/src/test/scala/com/expedia/www/haystack/trace/indexer/integration/clients/CassandraTestClient.scala
@@ -20,7 +20,7 @@ package com.expedia.www.haystack.trace.indexer.integration.clients
 import com.datastax.driver.core.{Cluster, ConsistencyLevel, SimpleStatement}
 import com.expedia.open.tracing.buffer.SpanBuffer
 import com.expedia.www.haystack.commons.retries.RetryOperation
-`import com.expedia.www.haystack.trace.commons.config.entities.{CassandraConfiguration, KeyspaceConfiguration, SocketConfiguration}
+import com.expedia.www.haystack.trace.commons.config.entities.{CassandraConfiguration, KeyspaceConfiguration, SocketConfiguration}
 import com.expedia.www.haystack.trace.indexer.config.entities.{CassandraWriteConfiguration, ServiceMetadataWriteConfiguration}
 
 import scala.collection.JavaConverters._

--- a/indexer/src/test/scala/com/expedia/www/haystack/trace/indexer/integration/clients/CassandraTestClient.scala
+++ b/indexer/src/test/scala/com/expedia/www/haystack/trace/indexer/integration/clients/CassandraTestClient.scala
@@ -20,16 +20,15 @@ package com.expedia.www.haystack.trace.indexer.integration.clients
 import com.datastax.driver.core.{Cluster, ConsistencyLevel, SimpleStatement}
 import com.expedia.open.tracing.buffer.SpanBuffer
 import com.expedia.www.haystack.commons.retries.RetryOperation
-import com.expedia.www.haystack.trace.commons.clients.cassandra.CassandraTableSchema
-import com.expedia.www.haystack.trace.commons.config.entities.{CassandraConfiguration, KeyspaceConfiguration, SocketConfiguration}
+`import com.expedia.www.haystack.trace.commons.config.entities.{CassandraConfiguration, KeyspaceConfiguration, SocketConfiguration}
 import com.expedia.www.haystack.trace.indexer.config.entities.{CassandraWriteConfiguration, ServiceMetadataWriteConfiguration}
 
 import scala.collection.JavaConverters._
 
 class CassandraTestClient {
+
   case class CassandraSpanRow(id: String, timestamp: java.util.Date, spanBuffer: SpanBuffer)
   case class ServiceMetadataRow(serviceName: String, operationName: String, timestamp: java.util.Date)
-
   private val CASSANDRA_ENDPOINT = "cassandra"
   private val KEYSPACE = "haystack"
   private val TABLE_NAME = "traces"
@@ -37,21 +36,12 @@ class CassandraTestClient {
   private val SERVICES_METADATA_KEYSPACE = "haystack_metadata"
   private val SERVICES_TABLE_NAME = "services"
   private val cassandraSession = Cluster.builder().addContactPoints(CASSANDRA_ENDPOINT).build().connect()
+  private val traceSchema = Some("CREATE KEYSPACE IF NOT EXISTS haystack WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor' : 1} AND durable_writes = false;\n\nCREATE TABLE haystack.traces (\nid varchar,\nts timestamp,\nspans blob,\nPRIMARY KEY ((id), ts)\n) WITH CLUSTERING ORDER BY (ts ASC);\n\nALTER TABLE haystack.traces WITH compaction = { 'class' :  'DateTieredCompactionStrategy'  };")
+  private val metadataSchema = Some("CREATE KEYSPACE IF NOT EXISTS haystack_metadata WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor' : 1} AND durable_writes = false;\n\nCREATE TABLE haystack_metadata.services (\nservice_name varchar,\noperation_name varchar,\nts timestamp,\nPRIMARY KEY ((service_name), operation_name)\n) WITH CLUSTERING ORDER BY (operation_name ASC);\n\nALTER TABLE haystack_metadata.services WITH compaction = { 'class' :  'DateTieredCompactionStrategy'  };")
 
   def prepare(): Unit = {
-    CassandraTableSchema.ensureExists(
-      KEYSPACE,
-      TABLE_NAME,
-      Some("CREATE KEYSPACE IF NOT EXISTS haystack WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor' : 1} AND durable_writes = false;\n\nCREATE TABLE haystack.traces (\nid varchar,\nts timestamp,\nspans blob,\nPRIMARY KEY ((id), ts)\n) WITH CLUSTERING ORDER BY (ts ASC);\n\nALTER TABLE haystack.traces WITH compaction = { 'class' :  'DateTieredCompactionStrategy'  };"),
-      cassandraSession)
-    cassandraSession.execute(new SimpleStatement(s"TRUNCATE $KEYSPACE.$TABLE_NAME"))
-
-    CassandraTableSchema.ensureExists(
-      SERVICES_METADATA_KEYSPACE,
-      SERVICES_TABLE_NAME,
-      Some("CREATE KEYSPACE IF NOT EXISTS haystack_metadata WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor' : 1} AND durable_writes = false;\n\nCREATE TABLE haystack_metadata.services (\nservice_name varchar,\noperation_name varchar,\nts timestamp,\nPRIMARY KEY ((service_name), operation_name)\n) WITH CLUSTERING ORDER BY (operation_name ASC);\n\nALTER TABLE haystack_metadata.services WITH compaction = { 'class' :  'DateTieredCompactionStrategy'  };"),
-      cassandraSession)
-    cassandraSession.execute(new SimpleStatement(s"TRUNCATE $SERVICES_METADATA_KEYSPACE.$SERVICES_TABLE_NAME"))
+    cassandraSession.execute(new SimpleStatement(s"DROP KEYSPACE  $KEYSPACE"))
+    cassandraSession.execute(new SimpleStatement(s"DROP KEYSPACE $SERVICES_METADATA_KEYSPACE"))
   }
 
   def buildServiceMetadataConfig: ServiceMetadataWriteConfiguration = {
@@ -61,7 +51,7 @@ class CassandraTestClient {
       1000,
       RetryOperation.Config(10, 250, 2),
       ConsistencyLevel.ONE,
-      KeyspaceConfiguration(SERVICES_METADATA_KEYSPACE, SERVICES_TABLE_NAME, 10000))
+      KeyspaceConfiguration(SERVICES_METADATA_KEYSPACE, SERVICES_TABLE_NAME, 10000, metadataSchema))
   }
 
   def buildConfig = CassandraWriteConfiguration(
@@ -69,7 +59,7 @@ class CassandraTestClient {
       autoDiscoverEnabled = false,
       None,
       None,
-      KeyspaceConfiguration(KEYSPACE, TABLE_NAME, 10000),
+      KeyspaceConfiguration(KEYSPACE, TABLE_NAME, 10000, traceSchema),
       SocketConfiguration(5, keepAlive = true, 5000, 5000)), ConsistencyLevel.ONE, 10, RetryOperation.Config(10, 250, 2), List((Class.forName("com.datastax.driver.core.exceptions.UnavailableException"), ConsistencyLevel.ANY)))
 
   def queryAllTraces(unpack: (Array[Byte] => SpanBuffer)): Seq[CassandraSpanRow] = {


### PR DESCRIPTION
The current code fails in case the cassandra keyspace is not present when the app starts. This bug isn't caught in the integration tests either since we create the keyspace before running the tests.