### PR TITLE
Ability to turn off graphite logback appender

### DIFF
--- a/indexer/src/main/resources/logback.xml
+++ b/indexer/src/main/resources/logback.xml
@@ -23,6 +23,7 @@
 
     <appender name="EmitToGraphiteLogbackAppender"
               class="com.expedia.www.haystack.metrics.appenders.logback.EmitToGraphiteLogbackAppender">
+        <enabled>${HAYSTACK_GRAPHITE_ENABLED:-true}</enabled>
         <host>${HAYSTACK_GRAPHITE_HOST}</host>
         <port>${HAYSTACK_GRAPHITE_PORT}</port>
         <subsystem>trace-indexer</subsystem>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <scala.major.version>2</scala.major.version>
         <scala.minor.version>12</scala.minor.version>
         <scala.tiny.version>5</scala.tiny.version>
-        <haystack.logback.metrics.appender.version>0.1.12</haystack.logback.metrics.appender.version>
+        <haystack.logback.metrics.appender.version>1.0.5</haystack.logback.metrics.appender.version>
         <scala.major.minor.version>${scala.major.version}.${scala.minor.version}</scala.major.minor.version>
         <scala-library.version>${scala.major.version}.${scala.minor.version}.${scala.tiny.version}</scala-library.version>
 

--- a/reader/src/main/resources/logback.xml
+++ b/reader/src/main/resources/logback.xml
@@ -23,6 +23,7 @@
 
     <appender name="EmitToGraphiteLogbackAppender"
               class="com.expedia.www.haystack.metrics.appenders.logback.EmitToGraphiteLogbackAppender">
+        <enabled>${HAYSTACK_GRAPHITE_ENABLED:-true}</enabled>
         <host>${HAYSTACK_GRAPHITE_HOST}</host>
         <port>${HAYSTACK_GRAPHITE_PORT}</port>
         <subsystem>trace-reader</subsystem>


### PR DESCRIPTION
Ability to turn off graphite logback appender
Default if not set is true to be backwards compatible.
Also updated to latest version of the logback metrics appender.