### PR TITLE
Set auto-gen span's service name to "unknown"

### DIFF
--- a/reader/src/main/scala/com/expedia/www/haystack/trace/reader/readers/utils/SpanUtils.scala
+++ b/reader/src/main/scala/com/expedia/www/haystack/trace/reader/readers/utils/SpanUtils.scala
@@ -102,7 +102,7 @@ object SpanUtils {
     val duration = (longestDurationSpan.getStartTime + longestDurationSpan.getDuration) - startTime
 
     val autoGenSpanBuilder = Span.newBuilder()
-      .setServiceName(earliestRoot.getServiceName)
+      .setServiceName(AUTOGEN_SERVICE_NAME)
       .setOperationName(AUTOGEN_OPERATION_NAME)
       .setTraceId(earliestRoot.getTraceId)
       .setSpanId(rootSpanId)
@@ -121,7 +121,8 @@ object SpanUtils {
 }
 
 object SpanMarkers {
-  val AUTOGEN_OPERATION_NAME = "auto-generated"
+  val AUTOGEN_SERVICE_NAME = "unknown"
+  val AUTOGEN_OPERATION_NAME = "unknown"
   val AUTOGEN_REASON_TAG = "X-HAYSTACK-AUTOGEN-REASON"
   val AUTOGEN_SPAN_ID_TAG = "X-HAYSTACK-AUTOGEN-SPAN-ID"
   val AUTOGEN_FLAG_TAG = "X-HAYSTACK-AUTOGEN"


### PR DESCRIPTION
When a trace is missing a span, we dont know what service is missing, so it is less confusing if we label the service as "unknown" rather than guessing (often incorrectly) that the service's name isthe same as the child span's service name.