### PR TITLE
If the "service" tag exists in the span, send it to ElasticSearch and

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,21 +252,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-protobuf</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-stub</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
         </dependency>

--- a/reader/src/main/scala/com/expedia/www/haystack/trace/reader/readers/utils/SpanMerger.scala
+++ b/reader/src/main/scala/com/expedia/www/haystack/trace/reader/readers/utils/SpanMerger.scala
@@ -53,8 +53,12 @@ object SpanMerger {
     Span
       .newBuilder(serverSpan)
       .setParentSpanId(clientSpan.getParentSpanId) // use the parentSpanId of the client span to stitch in the client's trace tree
-      .addAllTags((clientSpan.getTagsList.asScala ++ auxiliaryCommonTags(clientSpan, serverSpan) ++ auxiliaryClientTags(clientSpan) ++ auxiliaryServerTags(serverSpan)).asJavaCollection)
-      .clearLogs().addAllLogs((clientSpan.getLogsList.asScala ++ serverSpan.getLogsList.asScala.sortBy(_.getTimestamp)).asJavaCollection)
+      .addAllTags((clientSpan.getTagsList.asScala
+                ++ auxiliaryCommonTags(clientSpan, serverSpan)
+                ++ auxiliaryClientTags(clientSpan)
+                ++ auxiliaryServerTags(serverSpan)).asJavaCollection)
+      .clearLogs().addAllLogs((clientSpan.getLogsList.asScala
+                            ++ serverSpan.getLogsList.asScala.sortBy(_.getTimestamp)).asJavaCollection)
       .build()
   }
 
@@ -108,7 +112,7 @@ object SpanMerger {
 
   private def auxiliaryClientTags(span: Span): List[Tag] =
     List(
-      buildStringTag(AuxiliaryTags.CLIENT_SERVICE_NAME, span.getServiceName),
+      buildStringTag(AuxiliaryTags.CLIENT_SERVICE_NAME, SpanUtils.getEffectiveServiceName(span)),
       buildStringTag(AuxiliaryTags.CLIENT_OPERATION_NAME, span.getOperationName),
       buildStringTag(AuxiliaryTags.CLIENT_INFRASTRUCTURE_PROVIDER, extractTagStringValue(span, AuxiliaryTags.INFRASTRUCTURE_PROVIDER)),
       buildStringTag(AuxiliaryTags.CLIENT_INFRASTRUCTURE_LOCATION, extractTagStringValue(span, AuxiliaryTags.INFRASTRUCTURE_LOCATION)),
@@ -118,7 +122,7 @@ object SpanMerger {
 
   private def auxiliaryServerTags(span: Span): List[Tag] = {
     List(
-      buildStringTag(AuxiliaryTags.SERVER_SERVICE_NAME, span.getServiceName),
+      buildStringTag(AuxiliaryTags.SERVER_SERVICE_NAME, SpanUtils.getEffectiveServiceName(span)),
       buildStringTag(AuxiliaryTags.SERVER_OPERATION_NAME, span.getOperationName),
       buildStringTag(AuxiliaryTags.SERVER_INFRASTRUCTURE_PROVIDER, extractTagStringValue(span, AuxiliaryTags.INFRASTRUCTURE_PROVIDER)),
       buildStringTag(AuxiliaryTags.SERVER_INFRASTRUCTURE_LOCATION, extractTagStringValue(span, AuxiliaryTags.INFRASTRUCTURE_LOCATION)),


### PR DESCRIPTION
use it in the auxiliary tags when merging spans, instead of the span's
service name. Also clean up pom.xml dependencies to fix some warnings.