### PR TITLE
Cassandra resiliency

### DIFF
--- a/backends/cassandra/pom.xml
+++ b/backends/cassandra/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>haystack-trace-backends</artifactId>
         <groupId>com.expedia.www</groupId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/backends/memory/pom.xml
+++ b/backends/memory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>haystack-trace-backends</artifactId>
         <groupId>com.expedia.www</groupId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/backends/pom.xml
+++ b/backends/pom.xml
@@ -4,13 +4,13 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>haystack-trace-backends</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.8-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <artifactId>haystack-traces</artifactId>
         <groupId>com.expedia.www</groupId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>haystack-traces</artifactId>
         <groupId>com.expedia.www</groupId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/indexer/pom.xml
+++ b/indexer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>haystack-traces</artifactId>
         <groupId>com.expedia.www</groupId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-traces</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.8-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/reader/pom.xml
+++ b/reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>haystack-traces</artifactId>
         <groupId>com.expedia.www</groupId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
This change allows one to start cassandra backend and cassandra in a docker-compose without sequencing them

```
version: '3'
services:
  cassandra:
    image: cassandra:3.11.0
    environment:
      MAX_HEAP_SIZE: 256m
      HEAP_NEWSIZE: 256m
    ports:
      - "9042:9042"

  storage-db:
    image: haystack-trace-backend-cassandra
    ports:
      - "8090:8090"
    environment:
      HAYSTACK_GRAPHITE_ENABLED: "false"
    depends_on:
      - "cassandra"```