### PR TITLE
isRangeQuery FieldName metadata changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <properties>
         <project.jdk.version>1.8</project.jdk.version>
         <protobuf.version>3.4.0</protobuf.version>
-        <haystack-commons.version>1.0.63</haystack-commons.version>
+        <haystack-commons.version>1.0.64</haystack-commons.version>
 
         <logback.version>1.2.3</logback.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>

--- a/reader/src/main/scala/com/expedia/www/haystack/trace/reader/readers/TraceReader.scala
+++ b/reader/src/main/scala/com/expedia/www/haystack/trace/reader/readers/TraceReader.scala
@@ -92,12 +92,6 @@ class TraceReader(traceStore: TraceStore,
   def getFieldNames: Future[FieldNames] = {
     traceStore
       .getFieldNames
-      .map(names =>
-        FieldNames
-          .newBuilder()
-          .addAllNames(names.getNamesList)
-          .addAllFieldMetadata(names.getFieldMetadataList)
-          .build())
   }
 
   def getFieldValues(request: FieldValuesRequest): Future[FieldValues] = {

--- a/reader/src/main/scala/com/expedia/www/haystack/trace/reader/readers/TraceReader.scala
+++ b/reader/src/main/scala/com/expedia/www/haystack/trace/reader/readers/TraceReader.scala
@@ -95,7 +95,8 @@ class TraceReader(traceStore: TraceStore,
       .map(names =>
         FieldNames
           .newBuilder()
-          .addAllNames(names.asJavaCollection)
+          .addAllNames(names.getNamesList)
+          .addAllFieldMetadata(names.getFieldMetadataList)
           .build())
   }
 

--- a/reader/src/main/scala/com/expedia/www/haystack/trace/reader/stores/TraceStore.scala
+++ b/reader/src/main/scala/com/expedia/www/haystack/trace/reader/stores/TraceStore.scala
@@ -23,7 +23,7 @@ import scala.concurrent.Future
 trait TraceStore extends AutoCloseable {
   def getTrace(traceId: String): Future[Trace]
   def searchTraces(request: TracesSearchRequest): Future[Seq[Trace]]
-  def getFieldNames: Future[Seq[String]]
+  def getFieldNames: Future[FieldNames]
   def getFieldValues(request: FieldValuesRequest): Future[Seq[String]]
   def getTraceCounts(request: TraceCountsRequest): Future[TraceCounts]
   def getRawTraces(request: RawTracesRequest): Future[Seq[Trace]]

--- a/reader/src/test/scala/com/expedia/www/haystack/trace/reader/integration/BaseIntegrationTestSpec.scala
+++ b/reader/src/test/scala/com/expedia/www/haystack/trace/reader/integration/BaseIntegrationTestSpec.scala
@@ -250,7 +250,7 @@ trait BaseIntegrationTestSpec extends FunSpec with GivenWhenThen with Matchers w
   case class FieldWithMetadata(name: String, isRangeQuery: Boolean)
 
   protected def putWhitelistIndexFieldsInEs(fields: List[FieldWithMetadata]): Unit = {
-    val whitelistFields = for (field <- fields) yield WhitelistIndexField(field.name, IndexFieldType.string, aliases = Set(s"_$field"), field.isRangeQuery)
+    val whitelistFields = for (field <- fields) yield WhitelistIndexField(field.name, IndexFieldType.string, aliases = Set(s"_${field.name}"), field.isRangeQuery)
     esClient.execute(new Index.Builder(Serialization.write(WhiteListIndexFields(whitelistFields)))
       .index(ELASTIC_SEARCH_WHITELIST_INDEX)
       .`type`(ELASTIC_SEARCH_WHITELIST_TYPE)

--- a/reader/src/test/scala/com/expedia/www/haystack/trace/reader/integration/BaseIntegrationTestSpec.scala
+++ b/reader/src/test/scala/com/expedia/www/haystack/trace/reader/integration/BaseIntegrationTestSpec.scala
@@ -247,8 +247,10 @@ trait BaseIntegrationTestSpec extends FunSpec with GivenWhenThen with Matchers w
     }
   }
 
-  protected def putWhitelistIndexFieldsInEs(fields: List[String]): Unit = {
-    val whitelistFields = for (field <- fields) yield WhitelistIndexField(field, IndexFieldType.string, aliases = Set(s"_$field"))
+  case class FieldWithMetadata(name: String, isRangeQuery: Boolean)
+
+  protected def putWhitelistIndexFieldsInEs(fields: List[FieldWithMetadata]): Unit = {
+    val whitelistFields = for (field <- fields) yield WhitelistIndexField(field.name, IndexFieldType.string, aliases = Set(s"_$field"), field.isRangeQuery)
     esClient.execute(new Index.Builder(Serialization.write(WhiteListIndexFields(whitelistFields)))
       .index(ELASTIC_SEARCH_WHITELIST_INDEX)
       .`type`(ELASTIC_SEARCH_WHITELIST_TYPE)

--- a/reader/src/test/scala/com/expedia/www/haystack/trace/reader/integration/TraceServiceIntegrationTestSpec.scala
+++ b/reader/src/test/scala/com/expedia/www/haystack/trace/reader/integration/TraceServiceIntegrationTestSpec.scala
@@ -40,8 +40,9 @@ class TraceServiceIntegrationTestSpec extends BaseIntegrationTestSpec {
       val fieldNames = client.getFieldNames(Empty.newBuilder().build())
 
       Then("should return fieldNames available in index")
-      fieldNames.getNamesList.size() should be(2)
-      fieldNames.getNamesList.asScala.toList should contain allOf(field1, field2)
+      fieldNames.getNamesCount should be(2)
+      fieldNames.getFieldMetadataCount should be(2)
+      fieldNames.getNamesList.asScala.toList should contain allOf("abc", "def")
     }
   }
 

--- a/reader/src/test/scala/com/expedia/www/haystack/trace/reader/integration/TraceServiceIntegrationTestSpec.scala
+++ b/reader/src/test/scala/com/expedia/www/haystack/trace/reader/integration/TraceServiceIntegrationTestSpec.scala
@@ -32,8 +32,8 @@ class TraceServiceIntegrationTestSpec extends BaseIntegrationTestSpec {
   describe("TraceReader.getFieldNames") {
     it("should return names of enabled fields") {
       Given("trace in trace-backend and elasticsearch")
-      val field1 = "abc"
-      val field2 = "def"
+      val field1 = FieldWithMetadata("abc", isRangeQuery = true)
+      val field2 = FieldWithMetadata("def", isRangeQuery = false)
       putWhitelistIndexFieldsInEs(List(field1, field2))
 
       When("calling getFieldNames")


### PR DESCRIPTION
Refactored reader to reflect changes in idl to allow for metadata "isRangeQuery" to be attached to a whitelisted field name